### PR TITLE
Guard clauses and similar refactors for less nesting and noise. No changes to the exposed API.

### DIFF
--- a/src/drain.rs
+++ b/src/drain.rs
@@ -48,53 +48,45 @@ impl<T, const CAP: usize> Iterator for Drain<'_, T, CAP> {
     type Item = T;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.range_len > 0 {
-            let value = unsafe {
-                self.array
-                    .data
-                    .get_unchecked(self.range_start)
-                    .assume_init_read()
-            };
-            self.range_start += 1;
-            self.range_len -= 1;
-            Some(value)
-        } else {
-            None
+        if self.range_len == 0 {
+            return None;
         }
+        let value = unsafe {
+            self.array
+                .data
+                .get_unchecked(self.range_start)
+                .assume_init_read()
+        };
+        self.range_start += 1;
+        self.range_len -= 1;
+        Some(value)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
         (self.range_len, Some(self.range_len))
     }
 
-    fn count(self) -> usize
-    where
-        Self: Sized,
-    {
+    fn count(self) -> usize {
         self.range_len
     }
 
-    fn last(mut self) -> Option<Self::Item>
-    where
-        Self: Sized,
-    {
+    fn last(mut self) -> Option<Self::Item> {
         self.next_back()
     }
 }
 
 impl<T, const CAP: usize> DoubleEndedIterator for Drain<'_, T, CAP> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        if self.range_len > 0 {
-            self.range_len -= 1;
-            Some(unsafe {
-                self.array
-                    .data
-                    .get_unchecked(self.range_start + self.range_len)
-                    .assume_init_read()
-            })
-        } else {
-            None
+        if self.range_len == 0 {
+            return None;
         }
+        self.range_len -= 1;
+        Some(unsafe {
+            self.array
+                .data
+                .get_unchecked(self.range_start + self.range_len)
+                .assume_init_read()
+        })
     }
 }
 

--- a/src/into_iter.rs
+++ b/src/into_iter.rs
@@ -57,13 +57,12 @@ impl<T, const CAP: usize> Iterator for IntoIter<T, CAP> {
     type Item = T;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.start == self.end {
-            None
-        } else {
-            let index = self.start;
-            self.start += 1;
-            Some(unsafe { self.data.get_unchecked(index).assume_init_read() })
+        if self.start >= self.end {
+            return None;
         }
+        let index = self.start;
+        self.start += 1;
+        Some(unsafe { self.data.get_unchecked(index).assume_init_read() })
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -71,17 +70,11 @@ impl<T, const CAP: usize> Iterator for IntoIter<T, CAP> {
         (length, Some(length))
     }
 
-    fn count(self) -> usize
-    where
-        Self: Sized,
-    {
+    fn count(self) -> usize {
         self.end - self.start
     }
 
-    fn last(mut self) -> Option<Self::Item>
-    where
-        Self: Sized,
-    {
+    fn last(mut self) -> Option<Self::Item> {
         self.next_back()
     }
 
@@ -112,12 +105,11 @@ impl<T, const CAP: usize> Iterator for IntoIter<T, CAP> {
 
 impl<T, const CAP: usize> DoubleEndedIterator for IntoIter<T, CAP> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        if self.start == self.end {
-            None
-        } else {
-            self.end -= 1;
-            Some(unsafe { self.data.get_unchecked(self.end).assume_init_read() })
+        if self.start >= self.end {
+            return None;
         }
+        self.end -= 1;
+        Some(unsafe { self.data.get_unchecked(self.end).assume_init_read() })
     }
 
     // TODO: should this exist? it changes how panics drop the elements


### PR DESCRIPTION
Remove unneded where clauses, replace if-else expressions with guards, remove duplicate .min calls, replace simple generic types with impl shorthand syntax.